### PR TITLE
fix: Include query params when fetching files from dev server

### DIFF
--- a/crates/vite-rs-axum-0-8/README.md
+++ b/crates/vite-rs-axum-0-8/README.md
@@ -34,7 +34,7 @@ The exposed `ViteServe` service can be used as a fallback service or mounted at 
 
        println!("Starting server on http://localhost:3000");
 
-       let _ = axum::serve(
+       axum::serve(
            tokio::net::TcpListener::bind("127.0.0.1:3000").await.unwrap(),
            axum::Router::new()
                // we mount our Vite app to /
@@ -44,7 +44,8 @@ The exposed `ViteServe` service can be used as a fallback service or mounted at 
                // .fallback_service(ViteServe::new(Assets::boxed()))
                .into_make_service(),
        )
-       .await;
+       .await
+       .unwrap()
    }
    ```
 

--- a/crates/vite-rs-embed-macro/src/vite/mod.rs
+++ b/crates/vite-rs-embed-macro/src/vite/mod.rs
@@ -261,6 +261,7 @@ pub mod build {
 
                 pub fn get(path: &str) -> Option<#crate_path::ViteFile> {
                     let path = path.to_string();
+
                     std::thread::spawn(move || {
                         let client = #crate_path::vite_rs_dev_server::reqwest::blocking::Client::new();
                         let url = format!(
@@ -291,14 +292,6 @@ pub mod build {
                                 #etag
 
                                 let mut bytes = res.bytes().unwrap().to_vec();
-
-                                /// check if the path is a css file, if so, print a warning if the content type isn't text/css:
-                                if path.ends_with(".css") && !content_type.eq("text/css") {
-                                    println!(
-                                        "**WARNING**: A request for a CSS resource ({}) was served javascript. This is likely because you've referenced a CSS file in your HTML which was not in the `public` directory (configurable in the vite's config). This will still be fine in release builds, but the CSS won't be applied correctly in development. You can move the CSS file to the public directory (for example: `public/styles.css`) and reference it in your HTML with a `<link rel=\"stylesheet\" href=\"/styles.css\">` tag. Alternatively, you can import the CSS file in your JavaScript code with `import './styles.css';`.",
-                                        &url
-                                    );
-                                }
 
                                 Some(#crate_path::ViteFile {
                                     last_modified: None, /* we don't send this in dev! */


### PR DESCRIPTION
ViteJS's dev server uses the query and the path to load the correct resource.

For example http://resource/something.svg?import will return javascript and with the correct content-type header whereas the same URL without the query param will return an svg file.