### PR TITLE
fix: Add windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest] # todo: add 'windows-latest'
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         rust: [stable]
         experimental: [false]
         # Note: We're no longer reliant on nightly, so we can remove this.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: actions/checkout@master
       - name: Install npm packages for examples & tests
+        shell: bash
         run: |
           (cd ./crates/vite-rs/test_projects && npm ci)
           (cd ./crates/vite-rs-axum-0-8/test_projects/basic_usage_test/app && npm ci)
@@ -53,6 +54,7 @@ jobs:
           cargo test -p vite-rs-axum-0-8
           cargo test -p vite-rs-axum-0-8 --release
       - name: Run/compile examples
+        shell: bash
         run: |
           # VITE-RS
           cargo run -p vite-rs --example basic_usage

--- a/crates/vite-rs-axum-0-8/tests/basic_usage_test.rs
+++ b/crates/vite-rs-axum-0-8/tests/basic_usage_test.rs
@@ -185,10 +185,18 @@ async fn ensure_serves_index(app: axum::Router) {
     let body_bytes = body::to_bytes(response.into_body(), 2048).await.unwrap();
 
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
-    assert_eq!(body_bytes, "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <script type=\"module\">import { injectIntoGlobalHook } from \"/@react-refresh\";\ninjectIntoGlobalHook(window);\nwindow.$RefreshReg$ = () => {};\nwindow.$RefreshSig$ = () => (type) => type;</script>\n\n    <script type=\"module\" src=\"/@vite/client\"></script>\n\n    <title>Hello World</title>\n    <link rel=\"stylesheet\" href=\"/test.css\" />\n  </head>\n  <body>\n    <h1>Loading...</h1>\n    <script type=\"module\" src=\"/script.tsx\"></script>\n  </body>\n</html>\n");
+    if cfg!(windows) {
+        assert_eq!(body_bytes, "<!DOCTYPE html>\r\n<html lang=\"en\">\r\n  <head>\n    <script type=\"module\">import { injectIntoGlobalHook } from \"/@react-refresh\";\ninjectIntoGlobalHook(window);\nwindow.$RefreshReg$ = () => {};\nwindow.$RefreshSig$ = () => (type) => type;</script>\n\n    <script type=\"module\" src=\"/@vite/client\"></script>\n\r\n    <title>Hello World</title>\r\n    <link rel=\"stylesheet\" href=\"/test.css\" />\r\n  </head>\r\n  <body>\r\n    <h1>Loading...</h1>\r\n    <script type=\"module\" src=\"/script.tsx\"></script>\r\n  </body>\r\n</html>\r\n");
+    }else{
+        assert_eq!(body_bytes, "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <script type=\"module\">import { injectIntoGlobalHook } from \"/@react-refresh\";\ninjectIntoGlobalHook(window);\nwindow.$RefreshReg$ = () => {};\nwindow.$RefreshSig$ = () => (type) => type;</script>\n\n    <script type=\"module\" src=\"/@vite/client\"></script>\n\n    <title>Hello World</title>\n    <link rel=\"stylesheet\" href=\"/test.css\" />\n  </head>\n  <body>\n    <h1>Loading...</h1>\n    <script type=\"module\" src=\"/script.tsx\"></script>\n  </body>\n</html>\n");
+    }
 
     #[cfg(not(all(debug_assertions, not(feature = "debug-prod"))))]
-    assert_eq!(body_bytes, "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>Hello World</title>\n    <link rel=\"stylesheet\" href=\"/test.css\" />\n    <script type=\"module\" crossorigin src=\"/assets/index-CgRBhnJL.js\"></script>\n  </head>\n  <body>\n    <h1>Loading...</h1>\n  </body>\n</html>\n");
+    if cfg!(windows) {
+        assert_eq!(body_bytes, "<!DOCTYPE html>\r\n<html lang=\"en\">\r\n  <head>\r\n    <title>Hello World</title>\r\n    <link rel=\"stylesheet\" href=\"/test.css\" />\r\n    <script type=\"module\" crossorigin src=\"/assets/index-CgRBhnJL.js\"></script>\n  </head>\r\n  <body>\r\n    <h1>Loading...</h1>\r\r\n  </body>\r\n</html>\r\n");
+    }else{
+        assert_eq!(body_bytes, "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>Hello World</title>\n    <link rel=\"stylesheet\" href=\"/test.css\" />\n    <script type=\"module\" crossorigin src=\"/assets/index-CgRBhnJL.js\"></script>\n  </head>\n  <body>\n    <h1>Loading...</h1>\n  </body>\n</html>\n");
+    }
 }
 
 async fn ensure_serves_public_files(app: axum::Router) {
@@ -204,17 +212,25 @@ async fn ensure_serves_public_files(app: axum::Router) {
     let body_bytes = body::to_bytes(response.into_body(), 2048).await.unwrap();
 
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
-    assert_eq!(body_bytes, "body {\n  background-color: black;\n  color: white;\n  font-family: Arial, sans-serif;\n  padding: 42px;\n}\n");
+    if cfg!(windows) {
+        assert_eq!(body_bytes, "body {\r\n  background-color: black;\r\n  color: white;\r\n  font-family: Arial, sans-serif;\r\n  padding: 42px;\r\n}\r\n");
+    }else{
+        assert_eq!(body_bytes, "body {\n  background-color: black;\n  color: white;\n  font-family: Arial, sans-serif;\n  padding: 42px;\n}\n");
+    }
 
     #[cfg(not(all(debug_assertions, not(feature = "debug-prod"))))]
-    assert_eq!(body_bytes, "body {\n  background-color: black;\n  color: white;\n  font-family: Arial, sans-serif;\n  padding: 42px;\n}\n");
+    if cfg!(windows) {
+        assert_eq!(body_bytes, "body {\r\n  background-color: black;\r\n  color: white;\r\n  font-family: Arial, sans-serif;\r\n  padding: 42px;\r\n}\r\n");
+    }else{
+        assert_eq!(body_bytes, "body {\n  background-color: black;\n  color: white;\n  font-family: Arial, sans-serif;\n  padding: 42px;\n}\n");
+    }
 }
 
 async fn ensure_serves_imports(app: axum::Router) {
     let uri = if cfg!(all(debug_assertions, not(feature = "debug-prod"))) {
         "/script.tsx"
     } else {
-        "/assets/index-CgRBhnJL.js"
+        &format!("/assets{}index-CgRBhnJL.js", std::path::MAIN_SEPARATOR)
     };
 
     let request = http::Request::builder()

--- a/crates/vite-rs-axum-0-8/tests/basic_usage_test.rs
+++ b/crates/vite-rs-axum-0-8/tests/basic_usage_test.rs
@@ -230,7 +230,7 @@ async fn ensure_serves_imports(app: axum::Router) {
     let uri = if cfg!(all(debug_assertions, not(feature = "debug-prod"))) {
         "/script.tsx"
     } else {
-        &format!("/assets{}index-CgRBhnJL.js", std::path::MAIN_SEPARATOR)
+        "/assets/index-CgRBhnJL.js"
     };
 
     let request = http::Request::builder()

--- a/crates/vite-rs-axum-0-8/tests/basic_usage_test.rs
+++ b/crates/vite-rs-axum-0-8/tests/basic_usage_test.rs
@@ -187,14 +187,14 @@ async fn ensure_serves_index(app: axum::Router) {
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
     if cfg!(windows) {
         assert_eq!(body_bytes, "<!DOCTYPE html>\r\n<html lang=\"en\">\r\n  <head>\n    <script type=\"module\">import { injectIntoGlobalHook } from \"/@react-refresh\";\ninjectIntoGlobalHook(window);\nwindow.$RefreshReg$ = () => {};\nwindow.$RefreshSig$ = () => (type) => type;</script>\n\n    <script type=\"module\" src=\"/@vite/client\"></script>\n\r\n    <title>Hello World</title>\r\n    <link rel=\"stylesheet\" href=\"/test.css\" />\r\n  </head>\r\n  <body>\r\n    <h1>Loading...</h1>\r\n    <script type=\"module\" src=\"/script.tsx\"></script>\r\n  </body>\r\n</html>\r\n");
-    }else{
+    } else {
         assert_eq!(body_bytes, "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <script type=\"module\">import { injectIntoGlobalHook } from \"/@react-refresh\";\ninjectIntoGlobalHook(window);\nwindow.$RefreshReg$ = () => {};\nwindow.$RefreshSig$ = () => (type) => type;</script>\n\n    <script type=\"module\" src=\"/@vite/client\"></script>\n\n    <title>Hello World</title>\n    <link rel=\"stylesheet\" href=\"/test.css\" />\n  </head>\n  <body>\n    <h1>Loading...</h1>\n    <script type=\"module\" src=\"/script.tsx\"></script>\n  </body>\n</html>\n");
     }
 
     #[cfg(not(all(debug_assertions, not(feature = "debug-prod"))))]
     if cfg!(windows) {
         assert_eq!(body_bytes, "<!DOCTYPE html>\r\n<html lang=\"en\">\r\n  <head>\r\n    <title>Hello World</title>\r\n    <link rel=\"stylesheet\" href=\"/test.css\" />\r\n    <script type=\"module\" crossorigin src=\"/assets/index-CgRBhnJL.js\"></script>\n  </head>\r\n  <body>\r\n    <h1>Loading...</h1>\r\r\n  </body>\r\n</html>\r\n");
-    }else{
+    } else {
         assert_eq!(body_bytes, "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>Hello World</title>\n    <link rel=\"stylesheet\" href=\"/test.css\" />\n    <script type=\"module\" crossorigin src=\"/assets/index-CgRBhnJL.js\"></script>\n  </head>\n  <body>\n    <h1>Loading...</h1>\n  </body>\n</html>\n");
     }
 }
@@ -214,14 +214,14 @@ async fn ensure_serves_public_files(app: axum::Router) {
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
     if cfg!(windows) {
         assert_eq!(body_bytes, "body {\r\n  background-color: black;\r\n  color: white;\r\n  font-family: Arial, sans-serif;\r\n  padding: 42px;\r\n}\r\n");
-    }else{
+    } else {
         assert_eq!(body_bytes, "body {\n  background-color: black;\n  color: white;\n  font-family: Arial, sans-serif;\n  padding: 42px;\n}\n");
     }
 
     #[cfg(not(all(debug_assertions, not(feature = "debug-prod"))))]
     if cfg!(windows) {
         assert_eq!(body_bytes, "body {\r\n  background-color: black;\r\n  color: white;\r\n  font-family: Arial, sans-serif;\r\n  padding: 42px;\r\n}\r\n");
-    }else{
+    } else {
         assert_eq!(body_bytes, "body {\n  background-color: black;\n  color: white;\n  font-family: Arial, sans-serif;\n  padding: 42px;\n}\n");
     }
 }

--- a/crates/vite-rs-dev-server/src/lib.rs
+++ b/crates/vite-rs-dev-server/src/lib.rs
@@ -105,7 +105,30 @@ pub fn start_dev_server(
 
     // println!("Starting dev server!");
     // start ViteJS dev server
-    let child = Arc::new(Mutex::new(
+    let child = Arc::new(Mutex::new(if cfg!(target_os = "windows") {
+        std::process::Command::new("cmd")
+            .arg("/C")
+            .arg("npx")
+            .arg("vite")
+            .arg("--host")
+            .arg(host)
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--strictPort")
+            .arg("--clearScreen")
+            .arg("false")
+            // we don't want to send stdin to the dev server; this also
+            // hides the "press h + enter to show help" message that the dev server prints
+            .stdin(std::process::Stdio::null())
+            .current_dir(
+                absolute_root_dir, /*format!(
+                                       "{}/examples/basic_usage",
+                                       std::env::var("CARGO_MANIFEST_DIR").unwrap()
+                                   )*/
+            )
+            .group_spawn()
+            .expect("failed to start ViteJS dev server")
+    } else {
         std::process::Command::new("npx")
             .arg("vite")
             .arg("--host")
@@ -125,8 +148,8 @@ pub fn start_dev_server(
                                    )*/
             )
             .group_spawn()
-            .expect("failed to start ViteJS dev server"),
-    ));
+            .expect("failed to start ViteJS dev server")
+    }));
     set_dev_server(ViteProcess(child.clone()));
 
     #[cfg(feature = "ctrlc")]

--- a/crates/vite-rs-embed-macro/src/vite/mod.rs
+++ b/crates/vite-rs-embed-macro/src/vite/mod.rs
@@ -17,8 +17,8 @@ pub mod build {
             .map(|entry| {
                 let path = entry.path();
                 let path = path.strip_prefix(absolute_output_path).unwrap();
-                let path = path.to_str().unwrap().to_string();
-
+                let path = path.to_str().unwrap().replace("\\", "/");
+                
                 path
             })
             .filter(|path| !path.starts_with(".vite")) // ignore vite manifest or other vite-internal files
@@ -139,16 +139,12 @@ pub mod build {
                 .iter()
                 .filter(|e| e.1.isEntry.unwrap_or(false))
                 .for_each(|(key, value)| {
-                    let normalized_key = key.replace("/", &std::path::MAIN_SEPARATOR.to_string());
-                    if !match_values.contains_key(&normalized_key) {
+                    if !match_values.contains_key(key) {
                         aliases.insert(key.clone(), value.file.clone());
                     }
                 });
 
             aliases.into_iter().map(|(alias, path)| {
-                // On Windows, manifest paths are still forward slashes, so we need to fix that
-                let alias = alias.replace("/", &std::path::MAIN_SEPARATOR.to_string());
-                let path = path.replace("/", &std::path::MAIN_SEPARATOR.to_string());
                 quote! {
                     (#alias, #path),
                 }

--- a/crates/vite-rs-embed-macro/src/vite/mod.rs
+++ b/crates/vite-rs-embed-macro/src/vite/mod.rs
@@ -18,7 +18,7 @@ pub mod build {
                 let path = entry.path();
                 let path = path.strip_prefix(absolute_output_path).unwrap();
                 let path = path.to_str().unwrap().replace("\\", "/");
-                
+
                 path
             })
             .filter(|path| !path.starts_with(".vite")) // ignore vite manifest or other vite-internal files

--- a/crates/vite-rs/examples/basic_usage.rs
+++ b/crates/vite-rs/examples/basic_usage.rs
@@ -24,7 +24,7 @@ fn main() {
     }
 
     println!("Reading index.html:");
-    let file = Assets::get("app/index.html").unwrap();
+    let file = Assets::get(&format!("app{}index.html", std::path::MAIN_SEPARATOR)).unwrap();
     let file_content = std::str::from_utf8(&file.bytes).unwrap();
 
     println!("{}", file_content);
@@ -69,12 +69,12 @@ fn main() {
     );
 
     println!("Reading pack1.js:");
-    let file = Assets::get("app/pack1.ts").unwrap();
+    let file = Assets::get(&format!("app{}pack1.ts", std::path::MAIN_SEPARATOR)).unwrap();
     let file_content = std::str::from_utf8(&file.bytes).unwrap();
 
     println!("{}", file_content);
 
-    #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
+    #[cfg(all(debug_assertions, not(feature = "debug-prod"), not(windows)))]
     assert_eq!(
         strip_space(file_content),
         strip_space(
@@ -92,6 +92,24 @@ fn main() {
         )
     );
 
+    #[cfg(all(debug_assertions, not(feature = "debug-prod"), windows))]
+    assert_eq!(
+        strip_space(file_content),
+        strip_space(
+            r#"
+            const test = (() => {
+                console.log("This is a test");
+                const a = 3;
+                return a;
+            })();
+            const num = test;
+            console.log("NUM: ", num);
+
+            //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInBhY2sxLnRzIl0sInNvdXJjZXNDb250ZW50IjpbImNvbnN0IHRlc3QgPSAoKCkgPT4ge1xyXG4gIGNvbnNvbGUubG9nKCdUaGlzIGlzIGEgdGVzdCcpXHJcblxyXG4gIGNvbnN0IGE6IG51bWJlciA9IDNcclxuXHJcbiAgcmV0dXJuIGFcclxufSkoKVxyXG5cclxuY29uc3QgbnVtID0gdGVzdFxyXG5cclxuY29uc29sZS5sb2coJ05VTTogJywgbnVtKVxyXG4iXSwibWFwcGluZ3MiOiJBQUFBLE1BQU0sUUFBUSxNQUFNO0FBQ2xCLFVBQVEsSUFBSSxnQkFBZ0I7QUFFNUIsUUFBTSxJQUFZO0FBRWxCLFNBQU87QUFDVCxHQUFHO0FBRUgsTUFBTSxNQUFNO0FBRVosUUFBUSxJQUFJLFNBQVMsR0FBRzsiLCJuYW1lcyI6W119
+        "#
+        )
+    );
+
     #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
     assert_eq!(
         strip_space(file_content),
@@ -100,5 +118,5 @@ fn main() {
 }
 
 fn strip_space(s: &str) -> String {
-    s.trim().replace(" ", "")
+    s.trim().replace(" ", "").replace('\r', "")
 }

--- a/crates/vite-rs/examples/basic_usage.rs
+++ b/crates/vite-rs/examples/basic_usage.rs
@@ -24,7 +24,7 @@ fn main() {
     }
 
     println!("Reading index.html:");
-    let file = Assets::get(&format!("app{}index.html", std::path::MAIN_SEPARATOR)).unwrap();
+    let file = Assets::get("app/index.html").unwrap();
     let file_content = std::str::from_utf8(&file.bytes).unwrap();
 
     println!("{}", file_content);
@@ -69,7 +69,7 @@ fn main() {
     );
 
     println!("Reading pack1.js:");
-    let file = Assets::get(&format!("app{}pack1.ts", std::path::MAIN_SEPARATOR)).unwrap();
+    let file = Assets::get("app/pack1.ts").unwrap();
     let file_content = std::str::from_utf8(&file.bytes).unwrap();
 
     println!("{}", file_content);

--- a/crates/vite-rs/examples/custom_ctrl_c_handler.rs
+++ b/crates/vite-rs/examples/custom_ctrl_c_handler.rs
@@ -22,7 +22,7 @@ fn main() {
         std::thread::sleep(std::time::Duration::from_secs(2));
     }
 
-    let file = Assets::get(&format!("app{}index.html", std::path::MAIN_SEPARATOR)).unwrap();
+    let file = Assets::get("app/index.html").unwrap();
     let file_content = std::str::from_utf8(&file.bytes).unwrap();
 
     println!("Reading index.html:");

--- a/crates/vite-rs/examples/custom_ctrl_c_handler.rs
+++ b/crates/vite-rs/examples/custom_ctrl_c_handler.rs
@@ -22,7 +22,7 @@ fn main() {
         std::thread::sleep(std::time::Duration::from_secs(2));
     }
 
-    let file = Assets::get("app/index.html").unwrap();
+    let file = Assets::get(&format!("app{}index.html", std::path::MAIN_SEPARATOR)).unwrap();
     let file_content = std::str::from_utf8(&file.bytes).unwrap();
 
     println!("Reading index.html:");
@@ -69,5 +69,5 @@ fn main() {
 }
 
 fn strip_space(s: &str) -> String {
-    s.trim().replace(" ", "")
+    s.trim().replace(" ", "").replace("\r", "")
 }

--- a/crates/vite-rs/examples/vite-project-folder/vite.config.ts
+++ b/crates/vite-rs/examples/vite-project-folder/vite.config.ts
@@ -1,14 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
   build: {
     rollupOptions: {
-      input: ['app/index.html', 'app/pack1.ts'],
+      input: [path.resolve(__dirname, 'app/index.html'), path.resolve(__dirname, 'app/pack1.ts')],
     },
     manifest: true, // **IMPORTANT**: this is required.
-    outDir: './dist', // this is the default value
+    outDir: path.resolve(__dirname, './dist'),
   },
-  publicDir: './public', // this is the default value
+  publicDir: path.resolve(__dirname, './public'),
 })

--- a/crates/vite-rs/test_projects/recompilation_test/app/vite.config.ts
+++ b/crates/vite-rs/test_projects/recompilation_test/app/vite.config.ts
@@ -1,11 +1,10 @@
 import { defineConfig } from "vite";
-import path from "path";
 import { globSync } from "glob";
 
 export default defineConfig(() => ({
   build: {
     rollupOptions: {
-      input: globSync(path.resolve(__dirname, "*.txt")),
+      input: globSync("*.txt"),
     },
     manifest: true,
   },

--- a/crates/vite-rs/tests/normal_usage_test.rs
+++ b/crates/vite-rs/tests/normal_usage_test.rs
@@ -35,7 +35,15 @@ fn ensure_asset_list() {
     let mut list = Assets::iter().collect::<Vec<_>>();
     list.sort();
 
-    let mut expected = vec![
+    let mut expected = if cfg!(target_os = "windows") {vec![
+        "assets\\vite-DcBtz0py.svg",
+        "assets\\index-BZiJcslM.js",
+        "assets\\pack1-B2m_tRuS.js",
+        "assets\\index-BPvgi06w.css",
+        // ".vite\\manifest.json",
+        "test.txt",
+        "app\\index.html",
+    ]}else{vec![
         "assets/vite-DcBtz0py.svg",
         "assets/index-BZiJcslM.js",
         "assets/pack1-B2m_tRuS.js",
@@ -43,7 +51,7 @@ fn ensure_asset_list() {
         // ".vite/manifest.json",
         "test.txt",
         "app/index.html",
-    ];
+    ]};
     expected.sort();
 
     assert_eq!(list.len(), expected.len());
@@ -56,7 +64,7 @@ fn ensure_asset_list() {
 
 #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
 fn ensure_aliases() {
-    let aliases = vec![("app/pack1.ts", "assets/pack1-B2m_tRuS.js")];
+    let aliases = if cfg!(windows) {vec![("app\\pack1.ts", "assets\\pack1-B2m_tRuS.js")]} else {vec![("app/pack1.ts", "assets/pack1-B2m_tRuS.js")]};
 
     for alias in aliases {
         assert_eq!(
@@ -74,43 +82,77 @@ fn ensure_no_dot_vite_dir() {
 }
 
 fn ensure_html_entrypoint() {
-    let file = Assets::get("app/index.html").unwrap();
+    let file = Assets::get(&format!("app{}index.html", std::path::MAIN_SEPARATOR)).unwrap();
 
     assert_eq!(file.content_type, "text/html");
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
-    assert_eq!(file.content_length, 475);
+    if cfg!(windows) {
+        assert_eq!(file.content_length, 489);
+    } else {
+        assert_eq!(file.content_length, 475);
+    }
     #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
-    assert_eq!(file.content_length, 470);
+    if cfg!(windows) {
+        assert_eq!(file.content_length, 484);
+    } else {
+        assert_eq!(file.content_length, 470);
+    }
 
     let content = std::str::from_utf8(&file.bytes).unwrap();
 
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
-    assert_eq!(
-        content.replace(" ", ""),
-        "<!DOCTYPEhtml>\n<htmllang=\"en\">\n<head>\n<scripttype=\"module\"src=\"/@vite/client\"></script>\n\n<metacharset=\"UTF-8\"/>\n<linkrel=\"icon\"type=\"image/svg+xml\"href=\"./vite.svg\"/>\n<linkrel=\"stylsheet\"type=\"text/css\"href=\"./index.css\"/>\n<metaname=\"viewport\"content=\"width=device-width,initial-scale=1.0\"/>\n<title>vite-rs</title>\n</head>\n<body>\n<divid=\"root\"></div>\n<scripttype=\"module\"src=\"./index.ts\"></script>\n</body>\n</html>\n"
-        .replace(" ", "")
-    );
+    if cfg!(windows) {
+        assert_eq!(
+            content.replace(" ", ""),
+            "<!DOCTYPEhtml>\r\n<htmllang=\"en\">\r\n<head>\n<scripttype=\"module\"src=\"/@vite/client\"></script>\n\r\n<metacharset=\"UTF-8\"/>\r\n<linkrel=\"icon\"type=\"image/svg+xml\"href=\"./vite.svg\"/>\r\n<linkrel=\"stylsheet\"type=\"text/css\"href=\"./index.css\"/>\r\n<metaname=\"viewport\"content=\"width=device-width,initial-scale=1.0\"/>\r\n<title>vite-rs</title>\r\n</head>\r\n<body>\r\n<divid=\"root\"></div>\r\n<scripttype=\"module\"src=\"./index.ts\"></script>\r\n</body>\r\n</html>\r\n"
+            .replace(" ", "")
+        );
+    } else {
+        assert_eq!(
+            content.replace(" ", ""),
+            "<!DOCTYPEhtml>\n<htmllang=\"en\">\n<head>\n<scripttype=\"module\"src=\"/@vite/client\"></script>\n\n<metacharset=\"UTF-8\"/>\n<linkrel=\"icon\"type=\"image/svg+xml\"href=\"./vite.svg\"/>\n<linkrel=\"stylsheet\"type=\"text/css\"href=\"./index.css\"/>\n<metaname=\"viewport\"content=\"width=device-width,initial-scale=1.0\"/>\n<title>vite-rs</title>\n</head>\n<body>\n<divid=\"root\"></div>\n<scripttype=\"module\"src=\"./index.ts\"></script>\n</body>\n</html>\n"
+            .replace(" ", "")
+        );
+    }
 
     #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
-    assert_eq!(
-        content.replace(" ", ""),
-        "<!DOCTYPEhtml>\n<htmllang=\"en\">\n<head>\n<metacharset=\"UTF-8\"/>\n<linkrel=\"icon\"type=\"image/svg+xml\"href=\"/assets/vite-DcBtz0py.svg\"/>\n<metaname=\"viewport\"content=\"width=device-width,initial-scale=1.0\"/>\n<title>vite-rs</title>\n<scripttype=\"module\"crossoriginsrc=\"/assets/index-BZiJcslM.js\"></script>\n<linkrel=\"stylesheet\"crossoriginhref=\"/assets/index-BPvgi06w.css\">\n</head>\n<body>\n<divid=\"root\"></div>\n</body>\n</html>\n"
-        .replace(" ", "")
-    );
+    if cfg!(windows) {
+        assert_eq!(
+            content.replace(" ", ""),
+            "<!DOCTYPEhtml>\r\n<htmllang=\"en\">\r\n<head>\r\n<metacharset=\"UTF-8\"/>\r\n<linkrel=\"icon\"type=\"image/svg+xml\"href=\"/assets/vite-DcBtz0py.svg\"/>\r\r\n<metaname=\"viewport\"content=\"width=device-width,initial-scale=1.0\"/>\r\n<title>vite-rs</title>\r\n<scripttype=\"module\"crossoriginsrc=\"/assets/index-BZiJcslM.js\"></script>\n<linkrel=\"stylesheet\"crossoriginhref=\"/assets/index-BPvgi06w.css\">\n</head>\r\n<body>\r\n<divid=\"root\"></div>\r\r\n</body>\r\n</html>\r\n"
+            .replace(" ", "")
+        );
+    }else{
+        assert_eq!(
+            content.replace(" ", ""),
+            "<!DOCTYPEhtml>\n<htmllang=\"en\">\n<head>\n<metacharset=\"UTF-8\"/>\n<linkrel=\"icon\"type=\"image/svg+xml\"href=\"/assets/vite-DcBtz0py.svg\"/>\n<metaname=\"viewport\"content=\"width=device-width,initial-scale=1.0\"/>\n<title>vite-rs</title>\n<scripttype=\"module\"crossoriginsrc=\"/assets/index-BZiJcslM.js\"></script>\n<linkrel=\"stylesheet\"crossoriginhref=\"/assets/index-BPvgi06w.css\">\n</head>\n<body>\n<divid=\"root\"></div>\n</body>\n</html>\n"
+            .replace(" ", "")
+        );
+    }
 }
 
 fn ensure_ts_entrypoint() {
-    let file = Assets::get("app/pack1.ts").unwrap();
+    let file = Assets::get(&format!("app{}pack1.ts", std::path::MAIN_SEPARATOR)).unwrap();
     let content = std::str::from_utf8(&file.bytes).unwrap();
 
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
     {
-        assert_eq!(file.content_type, "text/javascript");
-        assert_eq!(file.content_length, 656);
-        assert_eq!(
-            content.replace(" ", ""),
-            "consttest=(()=>{\nconsole.log(\"Thisisatest\");\nconsta=3;\nreturna;\n})();\nconstnum=test;\nconsole.log(\"NUM:\",num);\n\n//#sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInBhY2sxLnRzIl0sInNvdXJjZXNDb250ZW50IjpbImNvbnN0IHRlc3QgPSAoKCkgPT4ge1xuICBjb25zb2xlLmxvZygnVGhpcyBpcyBhIHRlc3QnKVxuXG4gIGNvbnN0IGE6IG51bWJlciA9IDNcblxuICByZXR1cm4gYVxufSkoKVxuXG5jb25zdCBudW0gPSB0ZXN0XG5cbmNvbnNvbGUubG9nKCdOVU06ICcsIG51bSlcbiJdLCJtYXBwaW5ncyI6IkFBQUEsTUFBTSxRQUFRLE1BQU07QUFDbEIsVUFBUSxJQUFJLGdCQUFnQjtBQUU1QixRQUFNLElBQVk7QUFFbEIsU0FBTztBQUNULEdBQUc7QUFFSCxNQUFNLE1BQU07QUFFWixRQUFRLElBQUksU0FBUyxHQUFHOyIsIm5hbWVzIjpbXX0="
-        );
+        if cfg!(windows) {
+            assert_eq!(file.content_type, "text/javascript");
+            assert_eq!(file.content_length, 684);
+            assert_eq!(
+                content.replace(" ", ""),
+                "consttest=(()=>{\nconsole.log(\"Thisisatest\");\nconsta=3;\nreturna;\n})();\nconstnum=test;\nconsole.log(\"NUM:\",num);\n\n//#sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInBhY2sxLnRzIl0sInNvdXJjZXNDb250ZW50IjpbImNvbnN0IHRlc3QgPSAoKCkgPT4ge1xyXG4gIGNvbnNvbGUubG9nKCdUaGlzIGlzIGEgdGVzdCcpXHJcblxyXG4gIGNvbnN0IGE6IG51bWJlciA9IDNcclxuXHJcbiAgcmV0dXJuIGFcclxufSkoKVxyXG5cclxuY29uc3QgbnVtID0gdGVzdFxyXG5cclxuY29uc29sZS5sb2coJ05VTTogJywgbnVtKVxyXG4iXSwibWFwcGluZ3MiOiJBQUFBLE1BQU0sUUFBUSxNQUFNO0FBQ2xCLFVBQVEsSUFBSSxnQkFBZ0I7QUFFNUIsUUFBTSxJQUFZO0FBRWxCLFNBQU87QUFDVCxHQUFHO0FBRUgsTUFBTSxNQUFNO0FBRVosUUFBUSxJQUFJLFNBQVMsR0FBRzsiLCJuYW1lcyI6W119"
+            );
+        } else {
+            assert_eq!(file.content_type, "text/javascript");
+            assert_eq!(file.content_length, 656);
+            assert_eq!(
+                content.replace(" ", ""),
+                "consttest=(()=>{\nconsole.log(\"Thisisatest\");\nconsta=3;\nreturna;\n})();\nconstnum=test;\nconsole.log(\"NUM:\",num);\n\n//#sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInBhY2sxLnRzIl0sInNvdXJjZXNDb250ZW50IjpbImNvbnN0IHRlc3QgPSAoKCkgPT4ge1xuICBjb25zb2xlLmxvZygnVGhpcyBpcyBhIHRlc3QnKVxuXG4gIGNvbnN0IGE6IG51bWJlciA9IDNcblxuICByZXR1cm4gYVxufSkoKVxuXG5jb25zdCBudW0gPSB0ZXN0XG5cbmNvbnNvbGUubG9nKCdOVU06ICcsIG51bSlcbiJdLCJtYXBwaW5ncyI6IkFBQUEsTUFBTSxRQUFRLE1BQU07QUFDbEIsVUFBUSxJQUFJLGdCQUFnQjtBQUU1QixRQUFNLElBQVk7QUFFbEIsU0FBTztBQUNULEdBQUc7QUFFSCxNQUFNLE1BQU07QUFFWixRQUFRLElBQUksU0FBUyxHQUFHOyIsIm5hbWVzIjpbXX0="
+            );
+        }
+
     }
 
     #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
@@ -139,11 +181,11 @@ fn ensure_no_vite_manifest() {
 
 fn ensure_content_hash_is_correct() {
     let public_file = Assets::get("test.txt").unwrap();
-    let input_file = Assets::get("app/index.html").unwrap();
+    let input_file = Assets::get(&format!("app{}index.html", std::path::MAIN_SEPARATOR)).unwrap();
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
-    let included_file = Assets::get("app/index.ts").unwrap();
+    let included_file = Assets::get(&format!("app{}index.ts", std::path::MAIN_SEPARATOR)).unwrap();
     #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
-    let included_file = Assets::get("assets/index-BZiJcslM.js").unwrap();
+    let included_file = Assets::get(&format!("assets{}index-BZiJcslM.js", std::path::MAIN_SEPARATOR)).unwrap();
 
     check_hash(public_file);
     check_hash(input_file);

--- a/crates/vite-rs/tests/normal_usage_test.rs
+++ b/crates/vite-rs/tests/normal_usage_test.rs
@@ -35,23 +35,27 @@ fn ensure_asset_list() {
     let mut list = Assets::iter().collect::<Vec<_>>();
     list.sort();
 
-    let mut expected = if cfg!(target_os = "windows") {vec![
-        "assets\\vite-DcBtz0py.svg",
-        "assets\\index-BZiJcslM.js",
-        "assets\\pack1-B2m_tRuS.js",
-        "assets\\index-BPvgi06w.css",
-        // ".vite\\manifest.json",
-        "test.txt",
-        "app\\index.html",
-    ]}else{vec![
-        "assets/vite-DcBtz0py.svg",
-        "assets/index-BZiJcslM.js",
-        "assets/pack1-B2m_tRuS.js",
-        "assets/index-BPvgi06w.css",
-        // ".vite/manifest.json",
-        "test.txt",
-        "app/index.html",
-    ]};
+    let mut expected = if cfg!(target_os = "windows") {
+        vec![
+            "assets\\vite-DcBtz0py.svg",
+            "assets\\index-BZiJcslM.js",
+            "assets\\pack1-B2m_tRuS.js",
+            "assets\\index-BPvgi06w.css",
+            // ".vite\\manifest.json",
+            "test.txt",
+            "app\\index.html",
+        ]
+    } else {
+        vec![
+            "assets/vite-DcBtz0py.svg",
+            "assets/index-BZiJcslM.js",
+            "assets/pack1-B2m_tRuS.js",
+            "assets/index-BPvgi06w.css",
+            // ".vite/manifest.json",
+            "test.txt",
+            "app/index.html",
+        ]
+    };
     expected.sort();
 
     assert_eq!(list.len(), expected.len());
@@ -64,7 +68,11 @@ fn ensure_asset_list() {
 
 #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
 fn ensure_aliases() {
-    let aliases = if cfg!(windows) {vec![("app\\pack1.ts", "assets\\pack1-B2m_tRuS.js")]} else {vec![("app/pack1.ts", "assets/pack1-B2m_tRuS.js")]};
+    let aliases = if cfg!(windows) {
+        vec![("app\\pack1.ts", "assets\\pack1-B2m_tRuS.js")]
+    } else {
+        vec![("app/pack1.ts", "assets/pack1-B2m_tRuS.js")]
+    };
 
     for alias in aliases {
         assert_eq!(
@@ -122,7 +130,7 @@ fn ensure_html_entrypoint() {
             "<!DOCTYPEhtml>\r\n<htmllang=\"en\">\r\n<head>\r\n<metacharset=\"UTF-8\"/>\r\n<linkrel=\"icon\"type=\"image/svg+xml\"href=\"/assets/vite-DcBtz0py.svg\"/>\r\r\n<metaname=\"viewport\"content=\"width=device-width,initial-scale=1.0\"/>\r\n<title>vite-rs</title>\r\n<scripttype=\"module\"crossoriginsrc=\"/assets/index-BZiJcslM.js\"></script>\n<linkrel=\"stylesheet\"crossoriginhref=\"/assets/index-BPvgi06w.css\">\n</head>\r\n<body>\r\n<divid=\"root\"></div>\r\r\n</body>\r\n</html>\r\n"
             .replace(" ", "")
         );
-    }else{
+    } else {
         assert_eq!(
             content.replace(" ", ""),
             "<!DOCTYPEhtml>\n<htmllang=\"en\">\n<head>\n<metacharset=\"UTF-8\"/>\n<linkrel=\"icon\"type=\"image/svg+xml\"href=\"/assets/vite-DcBtz0py.svg\"/>\n<metaname=\"viewport\"content=\"width=device-width,initial-scale=1.0\"/>\n<title>vite-rs</title>\n<scripttype=\"module\"crossoriginsrc=\"/assets/index-BZiJcslM.js\"></script>\n<linkrel=\"stylesheet\"crossoriginhref=\"/assets/index-BPvgi06w.css\">\n</head>\n<body>\n<divid=\"root\"></div>\n</body>\n</html>\n"
@@ -152,7 +160,6 @@ fn ensure_ts_entrypoint() {
                 "consttest=(()=>{\nconsole.log(\"Thisisatest\");\nconsta=3;\nreturna;\n})();\nconstnum=test;\nconsole.log(\"NUM:\",num);\n\n//#sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInBhY2sxLnRzIl0sInNvdXJjZXNDb250ZW50IjpbImNvbnN0IHRlc3QgPSAoKCkgPT4ge1xuICBjb25zb2xlLmxvZygnVGhpcyBpcyBhIHRlc3QnKVxuXG4gIGNvbnN0IGE6IG51bWJlciA9IDNcblxuICByZXR1cm4gYVxufSkoKVxuXG5jb25zdCBudW0gPSB0ZXN0XG5cbmNvbnNvbGUubG9nKCdOVU06ICcsIG51bSlcbiJdLCJtYXBwaW5ncyI6IkFBQUEsTUFBTSxRQUFRLE1BQU07QUFDbEIsVUFBUSxJQUFJLGdCQUFnQjtBQUU1QixRQUFNLElBQVk7QUFFbEIsU0FBTztBQUNULEdBQUc7QUFFSCxNQUFNLE1BQU07QUFFWixRQUFRLElBQUksU0FBUyxHQUFHOyIsIm5hbWVzIjpbXX0="
             );
         }
-
     }
 
     #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
@@ -185,7 +192,11 @@ fn ensure_content_hash_is_correct() {
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
     let included_file = Assets::get(&format!("app{}index.ts", std::path::MAIN_SEPARATOR)).unwrap();
     #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
-    let included_file = Assets::get(&format!("assets{}index-BZiJcslM.js", std::path::MAIN_SEPARATOR)).unwrap();
+    let included_file = Assets::get(&format!(
+        "assets{}index-BZiJcslM.js",
+        std::path::MAIN_SEPARATOR
+    ))
+    .unwrap();
 
     check_hash(public_file);
     check_hash(input_file);

--- a/crates/vite-rs/tests/normal_usage_test.rs
+++ b/crates/vite-rs/tests/normal_usage_test.rs
@@ -35,27 +35,15 @@ fn ensure_asset_list() {
     let mut list = Assets::iter().collect::<Vec<_>>();
     list.sort();
 
-    let mut expected = if cfg!(target_os = "windows") {
-        vec![
-            "assets\\vite-DcBtz0py.svg",
-            "assets\\index-BZiJcslM.js",
-            "assets\\pack1-B2m_tRuS.js",
-            "assets\\index-BPvgi06w.css",
-            // ".vite\\manifest.json",
-            "test.txt",
-            "app\\index.html",
-        ]
-    } else {
-        vec![
-            "assets/vite-DcBtz0py.svg",
-            "assets/index-BZiJcslM.js",
-            "assets/pack1-B2m_tRuS.js",
-            "assets/index-BPvgi06w.css",
-            // ".vite/manifest.json",
-            "test.txt",
-            "app/index.html",
-        ]
-    };
+    let mut expected = vec![
+        "assets/vite-DcBtz0py.svg",
+        "assets/index-BZiJcslM.js",
+        "assets/pack1-B2m_tRuS.js",
+        "assets/index-BPvgi06w.css",
+        // ".vite/manifest.json",
+        "test.txt",
+        "app/index.html",
+    ];
     expected.sort();
 
     assert_eq!(list.len(), expected.len());
@@ -68,11 +56,7 @@ fn ensure_asset_list() {
 
 #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
 fn ensure_aliases() {
-    let aliases = if cfg!(windows) {
-        vec![("app\\pack1.ts", "assets\\pack1-B2m_tRuS.js")]
-    } else {
-        vec![("app/pack1.ts", "assets/pack1-B2m_tRuS.js")]
-    };
+    let aliases = vec![("app/pack1.ts", "assets/pack1-B2m_tRuS.js")];
 
     for alias in aliases {
         assert_eq!(
@@ -90,7 +74,7 @@ fn ensure_no_dot_vite_dir() {
 }
 
 fn ensure_html_entrypoint() {
-    let file = Assets::get(&format!("app{}index.html", std::path::MAIN_SEPARATOR)).unwrap();
+    let file = Assets::get("app/index.html").unwrap();
 
     assert_eq!(file.content_type, "text/html");
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
@@ -140,7 +124,7 @@ fn ensure_html_entrypoint() {
 }
 
 fn ensure_ts_entrypoint() {
-    let file = Assets::get(&format!("app{}pack1.ts", std::path::MAIN_SEPARATOR)).unwrap();
+    let file = Assets::get("app/pack1.ts").unwrap();
     let content = std::str::from_utf8(&file.bytes).unwrap();
 
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
@@ -188,15 +172,11 @@ fn ensure_no_vite_manifest() {
 
 fn ensure_content_hash_is_correct() {
     let public_file = Assets::get("test.txt").unwrap();
-    let input_file = Assets::get(&format!("app{}index.html", std::path::MAIN_SEPARATOR)).unwrap();
+    let input_file = Assets::get("app/index.html").unwrap();
     #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
-    let included_file = Assets::get(&format!("app{}index.ts", std::path::MAIN_SEPARATOR)).unwrap();
+    let included_file = Assets::get("app/index.ts").unwrap();
     #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
-    let included_file = Assets::get(&format!(
-        "assets{}index-BZiJcslM.js",
-        std::path::MAIN_SEPARATOR
-    ))
-    .unwrap();
+    let included_file = Assets::get("assets/index-BZiJcslM.js").unwrap();
 
     check_hash(public_file);
     check_hash(input_file);

--- a/crates/vite-rs/tests/recompilation_test.rs
+++ b/crates/vite-rs/tests/recompilation_test.rs
@@ -22,16 +22,19 @@ mod release_tests {
     pub fn ensure_binary_recompiles_on_asset_change() {
         delete_asset_if_exists(&format!("app{}test2.txt", std::path::MAIN_SEPARATOR));
         compile_test_project();
-        ensure_assets_exist(vec![
-            /* "app/test.txt" -> */ &format!("assets{}test-BPR99Ku7.txt", std::path::MAIN_SEPARATOR),
-        ]);
+        ensure_assets_exist(vec![/* "app/test.txt" -> */ &format!(
+            "assets{}test-BPR99Ku7.txt",
+            std::path::MAIN_SEPARATOR
+        )]);
         let binary_last_modified = get_compiled_binary_modified_time();
 
         add_asset(&format!("app{}test2.txt", std::path::MAIN_SEPARATOR), "123");
         compile_test_project();
         ensure_assets_exist(vec![
-            /* "app/test2.txt" -> */ &format!("assets{}test2-CajEw_O3.txt", std::path::MAIN_SEPARATOR),
-            /* "app/test.txt" -> */ &format!("assets{}test-BPR99Ku7.txt", std::path::MAIN_SEPARATOR),
+            /* "app/test2.txt" -> */
+            &format!("assets{}test2-CajEw_O3.txt", std::path::MAIN_SEPARATOR),
+            /* "app/test.txt" -> */
+            &format!("assets{}test-BPR99Ku7.txt", std::path::MAIN_SEPARATOR),
         ]);
         let binary_last_modified_2 = get_compiled_binary_modified_time();
 
@@ -123,8 +126,13 @@ mod release_tests {
         // let's make sure this comment is correct by doing this assertion:
         assert!(workspace_dir.ends_with(&format!("crates{}vite-rs", std::path::MAIN_SEPARATOR)));
 
-        let test_project_path =
-            PathBuf::from_iter(&[&workspace_dir, &format!("test_projects{}recompilation_test", std::path::MAIN_SEPARATOR)]);
+        let test_project_path = PathBuf::from_iter(&[
+            &workspace_dir,
+            &format!(
+                "test_projects{}recompilation_test",
+                std::path::MAIN_SEPARATOR
+            ),
+        ]);
 
         test_project_path
     }

--- a/crates/vite-rs/tests/recompilation_test.rs
+++ b/crates/vite-rs/tests/recompilation_test.rs
@@ -20,25 +20,24 @@ mod release_tests {
     use std::path::PathBuf;
 
     pub fn ensure_binary_recompiles_on_asset_change() {
-        delete_asset_if_exists(&format!("app{}test2.txt", std::path::MAIN_SEPARATOR));
+        delete_asset_if_exists("app/test2.txt");
         compile_test_project();
-        ensure_assets_exist(vec![/* "app/test.txt" -> */ &format!(
-            "assets{}test-BPR99Ku7.txt",
-            std::path::MAIN_SEPARATOR
-        )]);
+        ensure_assets_exist(vec![
+            /* "app/test.txt" -> */ "assets/test-BPR99Ku7.txt",
+        ]);
         let binary_last_modified = get_compiled_binary_modified_time();
 
-        add_asset(&format!("app{}test2.txt", std::path::MAIN_SEPARATOR), "123");
+        add_asset("app/test2.txt", "123");
         compile_test_project();
         ensure_assets_exist(vec![
             /* "app/test2.txt" -> */
-            &format!("assets{}test2-CajEw_O3.txt", std::path::MAIN_SEPARATOR),
+            "assets/test2-CajEw_O3.txt",
             /* "app/test.txt" -> */
-            &format!("assets{}test-BPR99Ku7.txt", std::path::MAIN_SEPARATOR),
+            "assets/test-BPR99Ku7.txt",
         ]);
         let binary_last_modified_2 = get_compiled_binary_modified_time();
 
-        delete_asset_if_exists(&format!("app{}test2.txt", std::path::MAIN_SEPARATOR)); // cleanup
+        delete_asset_if_exists("app/test2.txt"); // cleanup
 
         assert!(
             binary_last_modified_2 - binary_last_modified > 0,


### PR DESCRIPTION
1. Use commands through cmd.exe /C in Windows to ensures environment variables are loaded automatically 
2. Explicitly specify bash as shell for all runner because powershell doesn't support the && operator
3. Handle the difference between "\n" and "\r\n" on Linux and Windows
4. Handle the difference between path symbols on Linux and Windows