### PR TITLE
feat(vite-rs-axum-0-8): Support SPAs when used as a fallback_service #15

### DIFF
--- a/crates/vite-rs-axum-0-8/README.md
+++ b/crates/vite-rs-axum-0-8/README.md
@@ -49,6 +49,47 @@ The exposed `ViteServe` service can be used as a fallback service or mounted at 
    }
    ```
 
+## Single-Page Application (SPA) Routing
+
+In the default fallback strategy (`FallbackStrategy::NotFound`), requests for paths that don't match an embedded asset return `404` with an empty body ([caveat: ViteJS dev server responds 200 in all cases](#vitejs-invalid-path-response)). To let a client-side router (e.g. React Router, Vue Router) handle those paths instead, use `FallbackStrategy::SinglePageApplication`. The right setup depends on how you mount the `ViteServe` service.
+
+#### Option 1: Render SPA as a catch-all/fallback route
+
+The simplest setup: unmatched paths are already forwarded to `ViteServe` by Axum, so only the strategy needs to change.
+
+```diff
+use vite_rs_axum_0_8::{FallbackStrategy, ViteServe};
+
+axum::Router::new()
+    // ... your other routes ...
++    .fallback_service(
++        ViteServe::new(Assets::boxed())
++            .with_fallback_strategy(FallbackStrategy::SinglePageApplication("index.html".into()))
++    )
+```
+
+
+#### Option 2: Render SPA at a specific path
+
+It's required to use a two-route setup because `/` handles the root and `/{*path}` captures every deeper path.
+
+```diff
+use vite_rs_axum_0_8::{FallbackStrategy, ViteServe};
+
++let spa = ViteServe::new(Assets::boxed())
++    .with_fallback_strategy(FallbackStrategy::SinglePageApplication("index.html".into()));
+
+axum::Router::new()
++    .route_service("/", spa.clone())
++    .route_service("/{*path}", spa)
+```
+
+### Routing Response
+
+Any request that doesn't match an embedded asset is served `index.html` with a `200` response. If the named fallback file is not present in the asset map, the response falls back to `404`. 
+
+<a name="vitejs-invalid-path-response"></a>It should be noted that, in development, the ViteJS dev server serves the entrypoint (`index.html` by default) even at paths where resources don't exist.
+
 ## HTTP Caching Behaviour
 
 See [CacheStrategy rust docs](https://docs.rs/vite-rs-axum-0-8?search=CacheStrategy) for details on the caching strategies available. By default, release builds use the `Eager` caching strategy, while debug builds use `None`. You can override this by explicitly setting the cache strategy. Use them as follows:

--- a/crates/vite-rs-axum-0-8/src/lib.rs
+++ b/crates/vite-rs-axum-0-8/src/lib.rs
@@ -1,4 +1,4 @@
 mod vite_serve;
 mod vite_tower_service;
 
-pub use vite_serve::{CacheStrategy, ViteServe};
+pub use vite_serve::{CacheStrategy, FallbackStrategy, ViteServe};

--- a/crates/vite-rs-axum-0-8/src/vite_serve.rs
+++ b/crates/vite-rs-axum-0-8/src/vite_serve.rs
@@ -2,9 +2,23 @@ use axum::body::Body;
 use axum::response::Response;
 use vite_rs_interface::GetFromVite;
 
+/// Determines how unmatched paths are handled.
+#[derive(Clone)]
+pub enum FallbackStrategy {
+    /// Return 404 with an empty body for any path that doesn't match an embedded asset. (default)
+    ///
+    /// Note: In dev builds, the Vite dev server serves 200 even for non-existent paths with the content of `index.html` (or whichever entrypoint is configured)
+    NotFound,
+    /// Serve the given embedded file for any path that doesn't match an embedded asset, so client-side routers can handle the request.
+    ///
+    /// If the named file is not present in the embedded asset map, falls back to the NotFound strategy behaviour.
+    SinglePageApplication(String),
+}
+
 pub struct ViteServe {
     pub cache_strategy: CacheStrategy,
     pub assets: Box<dyn GetFromVite>,
+    pub fallback_strategy: FallbackStrategy,
 }
 
 impl Clone for ViteServe {
@@ -12,6 +26,7 @@ impl Clone for ViteServe {
         Self {
             cache_strategy: self.cache_strategy.clone(),
             assets: self.assets.clone_box(),
+            fallback_strategy: self.fallback_strategy.clone(),
         }
     }
 }
@@ -43,11 +58,17 @@ impl ViteServe {
             #[cfg(any(not(debug_assertions), feature = "debug-prod"))]
             cache_strategy: CacheStrategy::Eager,
             assets,
+            fallback_strategy: FallbackStrategy::NotFound,
         }
     }
 
     pub fn with_cache_strategy(mut self, cache_strategy: CacheStrategy) -> Self {
         self.cache_strategy = cache_strategy;
+        self
+    }
+
+    pub fn with_fallback_strategy(mut self, strategy: FallbackStrategy) -> Self {
+        self.fallback_strategy = strategy;
         self
     }
 
@@ -132,7 +153,20 @@ impl ViteServe {
                 }
             }
             None => {
-                // Return 404 Not Found with an empty body
+                match self.fallback_strategy {
+                    FallbackStrategy::SinglePageApplication(ref fallback_file) => {
+                        if let Some(index) = self.assets.get(fallback_file) {
+                            return Response::builder()
+                                .status(200)
+                                .header("Content-Type", index.content_type)
+                                .header("Content-Length", index.content_length)
+                                .body(Body::from(index.bytes))
+                                .unwrap();
+                        }
+                    }
+                    FallbackStrategy::NotFound => { /* logic below returns 404 as required */ }
+                }
+
                 #[cfg(all(debug_assertions, not(feature = "debug-prod")))]
                 return Response::builder()
                     .status(404)

--- a/crates/vite-rs-axum-0-8/tests/basic_usage_test.rs
+++ b/crates/vite-rs-axum-0-8/tests/basic_usage_test.rs
@@ -2,7 +2,7 @@ mod util;
 
 use reqwest::StatusCode;
 use tower::ServiceExt;
-use vite_rs_axum_0_8::ViteServe;
+use vite_rs_axum_0_8::{FallbackStrategy, ViteServe};
 
 use axum::{
     body::{self, Body},
@@ -45,6 +45,10 @@ async fn test() {
     test_custom_cache_strategy().await;
 
     test_cache_response().await;
+
+    test_fallback_not_found().await;
+    test_fallback_spa_found().await;
+    test_fallback_spa_missing_fallback_file().await;
 }
 
 fn app_with_fallback_service() -> axum::Router {
@@ -249,4 +253,88 @@ async fn ensure_serves_imports(app: axum::Router) {
 
     #[cfg(not(all(debug_assertions, not(feature = "debug-prod"))))]
     assert!(body_bytes.starts_with(b"(function(){const vl=document.createElement(\"link\").relList;if(vl&&vl.supports&&vl.supports(\"modulepreload\"))return;for(const Q of document.querySelectorAll('link[rel=\"modulepreload\"]'))r(Q);new MutationObserver(Q=>{for(const L of Q)if(L.type===\"childList\")for(const tl of L.addedNodes)tl.tagName===\"LINK\"&&tl.rel===\"modulepreload\"&&r(tl)}).observe(document,{childList:!0,subtree:!0});function J(Q){const L={};return Q.integrity&&(L.integrity=Q.integrity),Q.referrerPolicy&&(L.referrerPolicy=Q.referrerPolicy),Q.crossOrigin===\"use-credentials\"?L.credentials=\"include\":Q.crossOrigin===\"anonymous\"?L.credentials=\"omit\":L.credentials=\"same-origin\",L}function r(Q){if(Q.ep)return;Q.ep=!0;const L=J(Q);fetch(Q.href,L)}})();const R1=\"modulepreload\",H1=function(_){return\"/\"+_},wv={},N1=function(vl,J,r){let Q=Promise.resolve();if(J&&J.length>0){let tl=function(T){return Promise.all(T.map(U=>Promise.resolve(U).then(k=>({status:\"fulfilled\",value:k}),k=>({status:\"rejected\",reason:k}))))};document.getElementsByTagName(\"link\""));
+}
+
+/// FallbackStrategy::NotFound returns 404 with an empty body for unknown paths.
+///
+/// In dev builds the Vite dev server itself handles every path and returns index.html (200), so
+/// FallbackStrategy::NotFound is not enforced at the ViteServe layer during development.
+async fn test_fallback_not_found() {
+    let app = axum::Router::new().fallback_service(ViteServe::new(Assets::boxed()));
+
+    let request = http::Request::builder()
+        .uri("/this/path/does/not/exist")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    if cfg!(any(not(debug_assertions), feature = "debug-prod")) {
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body_bytes = body::to_bytes(response.into_body(), 256).await.unwrap();
+        assert!(body_bytes.is_empty());
+    } else {
+        // Dev: Vite dev server returns index.html for any unknown path.
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}
+
+/// FallbackStrategy::SinglePageApplication serves index.html (200) for unknown paths.
+///
+/// Both dev and prod return 200 with HTML content here — in prod ViteServe serves the embedded
+/// index.html; in dev the Vite dev server does it directly.
+async fn test_fallback_spa_found() {
+    let app = axum::Router::new().fallback_service(
+        ViteServe::new(Assets::boxed())
+            .with_fallback_strategy(FallbackStrategy::SinglePageApplication("index.html".into())),
+    );
+
+    let request = http::Request::builder()
+        .uri("/some/client/side/route")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    assert_eq!(
+        response
+            .headers()
+            .get("Content-Type")
+            .map(|h| h.to_str().unwrap()),
+        Some("text/html")
+    );
+
+    let body_bytes = body::to_bytes(response.into_body(), 4096).await.unwrap();
+    assert!(!body_bytes.is_empty());
+}
+
+/// FallbackStrategy::SinglePageApplication falls through to 404 when the named fallback file is
+/// not in the asset map.
+///
+/// In dev builds the Vite dev server answers before the missing-file check runs, so the response
+/// is 200 (index.html) rather than 404.
+async fn test_fallback_spa_missing_fallback_file() {
+    let app = axum::Router::new().fallback_service(
+        ViteServe::new(Assets::boxed()).with_fallback_strategy(
+            FallbackStrategy::SinglePageApplication("nonexistent.html".into()),
+        ),
+    );
+
+    let request = http::Request::builder()
+        .uri("/some/client/side/route")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    if cfg!(any(not(debug_assertions), feature = "debug-prod")) {
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body_bytes = body::to_bytes(response.into_body(), 256).await.unwrap();
+        assert!(body_bytes.is_empty());
+    } else {
+        // Dev: Vite dev server returns index.html regardless; missing-file check never fires.
+        assert_eq!(response.status(), StatusCode::OK);
+    }
 }


### PR DESCRIPTION
Adds `FallbackStrategy::NotFound` and `FallbackStartegy::SinglePageApplication`, see README.md for usage documentation